### PR TITLE
Fix integration tests

### DIFF
--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -80,8 +80,8 @@ echo - Waiting for bitcoind to warm up...
 btc -rpcwait getblockchaininfo > /dev/null
 
 echo - Creating wallets...
-btc createwallet internal > /dev/null
-btc createwallet bwt true true > /dev/null
+btc createwallet internal false false "" false false > /dev/null
+btc createwallet bwt true true "" false false > /dev/null
 
 echo - Generating some blocks...
 btc generatetoaddress 110 `btc getnewaddress` > /dev/null

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -36,7 +36,7 @@ if [[ $FEATURES == *"electrum"* ]]; then
   test `jq -r '.transactions | length' <<< "$hist"` == 2
   test `jq -r .transactions[0].confirmations <<< "$hist"` == 1
   test `jq -r .transactions[1].confirmations <<< "$hist"` == 0
-  test `jq -r .summary.end_balance <<< "$hist"` == 6.912
+  test `jq -r .summary.end.BTC_balance <<< "$hist"` == 6.912
   test `jq -r .transactions[0].bc_value <<< "$hist" | cut -d' ' -f1` == 1.234
 
   echo - Testing listunspent


### PR DESCRIPTION
Bitcoin Core 23 now creates descriptor wallets by default, breaking the integration tests. The first commit creates legacy wallets instead to fix this.

Electrum 4.1.0 replaced the `end_balance` field with `end.BTC_balance`. The second commit updates the query string to account for this.